### PR TITLE
支持.NET 4.0

### DIFF
--- a/DouyuDanmu.NET/DouyuClient.cs
+++ b/DouyuDanmu.NET/DouyuClient.cs
@@ -27,7 +27,7 @@ namespace DouyuDanmu
 
         public async void Connect()
         {
-            IPAddress[] ips = await Dns.GetHostAddressesAsync(Host);
+            IPAddress[] ips = Dns.GetHostAddresses(Host);
             var connected = await client.ConnectAsync(new IPEndPoint(ips.First(), Port));
 
             if (connected)

--- a/DouyuDanmu.NET/DouyuDanmu.csproj
+++ b/DouyuDanmu.NET/DouyuDanmu.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DouyuDanmu</RootNamespace>
     <AssemblyName>DouyuDanmu.NET</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,12 +34,24 @@
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="SuperSocket.ClientEngine, Version=0.7.0.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SuperSocket.ClientEngine.0.7.0.1\lib\net45\SuperSocket.ClientEngine.dll</HintPath>
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SuperSocket.ProtoBase, Version=1.7.0.5, Culture=neutral, PublicKeyToken=6c80000676988ebb, processorArchitecture=MSIL">
-      <HintPath>..\packages\SuperSocket.ProtoBase.1.7.0.5\lib\net35-client\SuperSocket.ProtoBase.dll</HintPath>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SuperSocket.ClientEngine, Version=0.8.0.7, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SuperSocket.ClientEngine.0.8.0.7\lib\net40-client\SuperSocket.ClientEngine.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SuperSocket.ProtoBase, Version=1.7.0.12, Culture=neutral, PublicKeyToken=6c80000676988ebb, processorArchitecture=MSIL">
+      <HintPath>..\packages\SuperSocket.ProtoBase.1.7.0.12\lib\net35-client\SuperSocket.ProtoBase.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -46,7 +59,20 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.IO, Version=2.6.8.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.8\lib\net40\System.IO.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Runtime, Version=2.6.8.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.8\lib\net40\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Threading.Tasks, Version=2.6.8.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.8\lib\net40\System.Threading.Tasks.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DouyuClient.cs" />
@@ -60,6 +86,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/DouyuDanmu.NET/DouyuPackageInfo.cs
+++ b/DouyuDanmu.NET/DouyuPackageInfo.cs
@@ -10,7 +10,7 @@ namespace DouyuDanmu
         public static int HeaderSize = 8;
         public static int HeaderFullSize = 12;
 
-        public enum MessageType : Int16
+        public enum MessageType : short
         {
             CLIENT_TO_SERVER = 689,
             SERVER_TO_CLIENT = 690

--- a/DouyuDanmu.NET/DouyuUtility.cs
+++ b/DouyuDanmu.NET/DouyuUtility.cs
@@ -34,7 +34,7 @@ namespace DouyuDanmu
                     string key = pair.Substring(0, pos);
                     string value = pair.Substring(pos + 2);
 
-                    dict.Add(Descape(key), Descape(value));
+                    dict[Descape(key)] = Descape(value);
                 }
             }
 

--- a/DouyuDanmu.NET/app.config
+++ b/DouyuDanmu.NET/app.config
@@ -6,6 +6,14 @@
         <assemblyIdentity name="SuperSocket.ProtoBase" publicKeyToken="6c80000676988ebb" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.7.0.5" newVersion="1.7.0.5" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.8.0" newVersion="2.6.8.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.8.0" newVersion="2.6.8.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" /></startup></configuration>

--- a/DouyuDanmu.NET/packages.config
+++ b/DouyuDanmu.NET/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SuperSocket.ClientEngine" version="0.7.0.1" targetFramework="net46" />
-  <package id="SuperSocket.ProtoBase" version="1.7.0.5" targetFramework="net46" />
+  <package id="Microsoft.Bcl" version="1.1.8" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
+  <package id="SuperSocket.ClientEngine" version="0.8.0.7" targetFramework="net40" />
+  <package id="SuperSocket.ProtoBase" version="1.7.0.12" targetFramework="net40" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DouyuDanmu.NET
-依照《斗鱼弹幕服务器第三方接入协议》(v1.4.1), 接入斗鱼弹幕服务的客户端C#类库实现, 基于.NET 4.6
+依照《斗鱼弹幕服务器第三方接入协议》(v1.4.1), 接入斗鱼弹幕服务的客户端C#类库实现, 基于.NET 4.0
 
 ~~~~
   using DouyuDanmu;
@@ -23,3 +23,10 @@
   // 开始接收弹幕
   client.Connect();
 ~~~~
+
+引用的Nuget包：
+* SuperSocket.ClientEngine
+* SuperSocket.ProtoBase
+* Microsoft.Bcl
+* Microsoft.Bcl.Async
+* Microsoft.Bcl.Build


### PR DESCRIPTION
1. 通过Microsoft.Bcl包在不修改代码的情况下支持.NET Framework 4.0
2. 更新了引用的SuperSocket库的版本
3. 修复了向Dictionary添加Key时会冲突的bug（见代码改动）